### PR TITLE
Separate upgrade and installation guides

### DIFF
--- a/.vitepress/config/sidebar.ts
+++ b/.vitepress/config/sidebar.ts
@@ -8,6 +8,7 @@ export const sidebar: SidebarConfig = {
         { text: 'Introduction', link: '/guide/introduction' },
         { text: 'Install', link: '/guide/install' },
         { text: 'Server configuration', link: '/guide/server-configuration' },
+        { text: 'Upgrade', link: '/guide/upgrade' },
       ],
     },
     {

--- a/src/guide/install.md
+++ b/src/guide/install.md
@@ -1,15 +1,14 @@
-# Installing and updating YOURLS
+# Installation
 
-Installing or updating YOURLS is not a difficult task. Some webhosts even automate the process, with tools such as CPanel.
-
-Here are the instructions to do it manually by yourself.
+Installing and updating YOURLS is a simple task.
+Some hosts provide process automation, with tools such as CPanel.
 
 :::tip Prerequisites
 This part of the documentation assumes basic familiarity with software deployment or system administration.
 If you are totally new to web app management, it might not be the best idea to jump right into the project as your first step - grasp the basics then come back!
 :::
 
-## Install YOURLS
+## Manual instructions
 
 1. Grab the [latest release archive](https://github.com/YOURLS/YOURLS/releases)
 2. Unzip the YOURLS archive
@@ -20,16 +19,6 @@ If you are totally new to web app management, it might not be the best idea to j
 7. Point your browser to `https://your-own-domain-here.com/admin/`
 8. Follow the installation procedure
 
-## Update YOURLS
-
-Every now and then a new version of YOURLS is available, and you will get the information right in your admin interface.
-
-1. **Backup your database** !
-2. Grab the [latest release archive](https://github.com/YOURLS/YOURLS/releases)
-3. Unzip the YOURLS archive
-4. Upload all files to your server, overwriting your existing install (this won't affect user files such as config or plugins)
-5. Point your browser to `https://your-own-domain-here.com/admin/`
-
-## Installation guides
+## Third party guides
 
 Head to [Awesome YOURLS](https://github.com/YOURLS/awesome-yourls#guides--tutorials) for installation guides covering specific environments, translated in different languages.

--- a/src/guide/upgrade.md
+++ b/src/guide/upgrade.md
@@ -1,0 +1,11 @@
+# Upgrade
+
+:::tip
+When a new version is available, a notification is shown on the admin interface.
+:::
+
+1. **Backup your database**!
+2. Grab the [latest release archive](https://github.com/YOURLS/YOURLS/releases)
+3. Unzip the YOURLS archive
+4. Upload all files to your server, overwriting your existing install (this won't affect user files such as config or plugins)
+5. Point your browser to `https://your-own-domain-here.com/admin/`


### PR DESCRIPTION
With the move to a better engine, there is more space to split actions to single page and clarify navigation.
While upgrade is close to installation in terms of steps to do, it is quite far from management point of view (you don't upgrade when you are installing, neither the opposite).

Plus little clarifications 😊